### PR TITLE
Fix #6: plugin loading inside tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ install:  ## Install package for development
 	@pip install -r requirements-dev.txt
 
 test:
-	@py.test --testdox tests/ --cov pytest_testdox --cov-report=xml
+	@py.test tests/ --cov pytest_testdox --cov-report=xml
 
 check:  ## Run static code checks
 	isort --check

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
--e .
+pytest>=3.0.0
 bumpversion==0.5.3
 flake8==3.3.0
 isort==4.2.5

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,7 +1,15 @@
 # -*- coding: utf-8 -*-
+import pytest
 
 
 class TestReport(object):
+
+    @pytest.fixture
+    def testdir(self, testdir):
+        testdir.makeconftest("""
+            pytest_plugins = 'pytest_testdox.plugin'
+        """)
+        return testdir
 
     def test_should_print_a_passing_test(self, testdir):
         testdir.makepyfile("""


### PR DESCRIPTION
Remove testdox formatter from CI tests :disappointed: and force pytester to load it in report test cases.

It turns out that the plugin was loaded by the setup.py entrypoint in the tests, so coverage.py couldn't register when it was loaded.