### PR TITLE
Improve module name output

### DIFF
--- a/pytest_testdox/formatters.py
+++ b/pytest_testdox/formatters.py
@@ -9,16 +9,13 @@ def format_outcome(outcome):
 
 
 def format_title(title, patterns):
-    return _remove_patterns(
-        patterns=patterns,
-        statement=title
-    ).replace('_', ' ').strip()
+    return _remove_patterns(title, patterns).replace('_', ' ').strip()
 
 
 def format_class_name(class_name, patterns):
     formatted = ''
 
-    class_name = _remove_patterns(patterns, class_name)
+    class_name = _remove_patterns(class_name, patterns)
 
     for letter in class_name:
         if letter.isupper():
@@ -30,13 +27,10 @@ def format_class_name(class_name, patterns):
 
 
 def format_module_name(module_name, patterns):
-    return format_title(
-        _remove_patterns(patterns, module_name),
-        patterns
-    ).replace('/', '.')
+    return format_title(module_name, patterns).replace('/', '.')
 
 
-def _remove_patterns(patterns, statement):
+def _remove_patterns(statement, patterns):
     for glob_pattern in patterns:
         pattern = glob_pattern.replace('*', '')
 
@@ -52,7 +46,7 @@ def _remove_patterns(patterns, statement):
             infix_patterns = glob_pattern.split('*', 2)
             infix_patterns[0] = '{}*'.format(infix_patterns[0])
             infix_patterns[1] = '*{}'.format(infix_patterns[1])
-            statement = _remove_patterns(infix_patterns, statement)
+            statement = _remove_patterns(statement, infix_patterns)
 
         else:
             pattern = '^{0}'.format(pattern)

--- a/pytest_testdox/formatters.py
+++ b/pytest_testdox/formatters.py
@@ -27,7 +27,7 @@ def format_class_name(class_name, patterns):
 
 
 def format_module_name(module_name, patterns):
-    return format_title(module_name, patterns).replace('/', '.')
+    return format_title(module_name.split('/')[-1], patterns)
 
 
 def _remove_patterns(statement, patterns):

--- a/pytest_testdox/plugin.py
+++ b/pytest_testdox/plugin.py
@@ -29,11 +29,21 @@ class TestdoxTerminalReporter(TerminalReporter):
 
     _last_header = ''
 
-    def pytest_runtest_logreport(self, report):
+    def _register_stats(self, report):
+        """
+        This method is not created for this plugin, but it is needed in order
+        to the reporter display the tests summary at the end.
+
+        Originally from:
+        https://github.com/pytest-dev/pytest/blob/47a2a77/_pytest/terminal.py#L198-L201
+        """
         res = self.config.hook.pytest_report_teststatus(report=report)
         category = res[0]
         self.stats.setdefault(category, []).append(report)
         self._tests_ran = True
+
+    def pytest_runtest_logreport(self, report):
+        self._register_stats(report)
 
         if report.when != 'call':
             return

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -73,10 +73,13 @@ class TestFormatModuleName(object):
         )
         assert formatters.format_module_name('a_test.py', patterns) == 'a test'
 
-    def test_should_replace_slashes_with_dots(self, patterns):
-        assert formatters.format_module_name('sub/module.py', patterns) == (
-            'sub.module'
+    def test_should_remove_folders_from_the_name(self, patterns):
+        formatted = formatters.format_module_name(
+            'tests/sub/test_module.py',
+            patterns
         )
+
+        assert formatted == 'module'
 
     def test_should_remove_infix_glob_patterns(self):
         formatted = formatters.format_module_name(

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -29,7 +29,7 @@ class TestParseNodeId(object):
         assert node.title == formatters.format_title('test_title',
                                                      pattern_config.functions)
         assert node.module_name == (
-            formatters.format_module_name('tests.test_module',
+            formatters.format_module_name('tests/test_module.py',
                                           pattern_config.files)
         )
 


### PR DESCRIPTION
I've included some refactors in this PR, but the target here is improve the headers when the test functions are in a module instead of a class, ex:

For a file `tests/sub/test_example.py` with
```python
def test_something():
    assert True


def test_another_thing():
    assert False
```

output before
```
collected 2 items

tests/sub/test_example.py

tests.sub.test example
- [x] something
- [ ] another thing
```

output after
``` 
collected 2 items

tests/sub/test_example.py

example
- [x] something
- [ ] another thing
```