### PR TITLE
Update six version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     keywords='pytest testdox test report bdd',
     install_requires=[
         'pytest>=3.0.0',
-        'six==1.10.0',
+        'six>=1.11.0',
     ],
     packages=['pytest_testdox'],
     classifiers=[


### PR DESCRIPTION
I had a problem with pytest-testdox after upgrading `pdbpp` and `ipython` because of six version in setup.py:

```
_pytest.vendored_packages.pluggy.PluginValidationError: Plugin 'testdox' could not be loaded: (six 1.11.0 (/Users/romulo/.virtualenvs/project/lib/python2.7/site-packages), Requirement.parse('six==1.10.0'))!
```

I've also changed to the version lock from `==` to `>=`.