### PR TITLE
Minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ install:  ## Install package for development
 	@pip install -r requirements-dev.txt
 
 test:
-	@py.test tests/ --cov pytest_testdox --cov-report=xml
+	@pytest tests/ --cov pytest_testdox --cov-report=xml
 
 check:  ## Run static code checks
 	isort --check

--- a/pytest_testdox/formatters.py
+++ b/pytest_testdox/formatters.py
@@ -34,7 +34,7 @@ def _remove_patterns(statement, patterns):
             pattern = '{0}$'.format(pattern)
             statement = re.sub(pattern, '', statement)
 
-        elif glob_pattern.endswith('*'):
+        elif glob_pattern.endswith('*'):
             pattern = '^{0}'.format(pattern)
             statement = re.sub(pattern, '', statement)
 

--- a/pytest_testdox/models.py
+++ b/pytest_testdox/models.py
@@ -41,12 +41,15 @@ class Node(object):
             pattern_config.files
         )
 
-        class_name = node_parts[-2]
-        if '()' not in class_name:
-            class_name = None
-        else:
+        class_name = None
+        if '()' in node_parts[-2]:
             class_name = formatters.format_class_name(
                 node_parts[-3],
+                pattern_config.classes
+            )
+        elif len(node_parts) > 2:
+            class_name = formatters.format_class_name(
+                node_parts[-2],
                 pattern_config.classes
             )
 

--- a/pytest_testdox/plugin.py
+++ b/pytest_testdox/plugin.py
@@ -56,7 +56,10 @@ class TestdoxTerminalReporter(TerminalReporter):
         Originally from:
         https://github.com/pytest-dev/pytest/blob/47a2a77/_pytest/terminal.py#L198-L201
         """
-        res = self.config.hook.pytest_report_teststatus(report=report)
+        res = self.config.hook.pytest_report_teststatus(
+            report=report,
+            config=self.config
+        )
         category = res[0]
         self.stats.setdefault(category, []).append(report)
         self._tests_ran = True

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -44,6 +44,10 @@ class TestNode(object):
         (
             'tests/test_module.py::TestClassName::()::test_title',
             formatters.format_class_name('TestClassName', ['Test*'])
+        ),
+        (
+            'tests/test_module.py::TestClassName::test_title',
+            formatters.format_class_name('TestClassName', ['Test*'])
         )
     ))
     def test_parse_with_class_name(self, pattern_config, nodeid, class_name):


### PR DESCRIPTION
As I was implementing #19, I've seen some minor things that were not related to the issue and could be improved.

As nobody complained about it, it doesn't even worth a creating a new release for it. But here it is 😄:

* Replace `py.test` command with `pytest` in Makefile
* Fix warning of missing `config` parameter in `pytest_report_teststatus` hook.
* Fix class name parsing when there are not parentesis in `nodeid`