### PR TITLE
Create markers to override class names and test titles in report

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,59 @@ in your `ini file <https://docs.pytest.org/en/latest/customize.html#initializati
     addopts = --testdox
 
 
+Markers
+-------
+
+@pytest.mark.describe
+---------------------
+
+Override the class name in the testdox report. Example
+
+.. code-block:: python
+
+    # test_demo.py
+    @pytest.mark.describe('create_file')
+    class TestCreateFile():
+
+        def test_creates_a_file_in_the_so(self):
+            pass
+
+
+Will produce the output:
+
+::
+
+    test_demo.py
+
+    create_file
+     [x] creates a file in the so
+
+
+@pytest.mark.it
+---------------
+
+Override the test title in the testdox report. Example:
+
+.. code-block:: python
+
+    # test_demo.py
+    class TestCreateFile():
+
+        @pytest.mark.it('Creates a local file in the SO')
+        def test_creates_a_file_in_the_so(self):
+            pass
+
+
+Will produce the output:
+
+::
+
+    test_demo.py
+
+    Create File
+     [x] Creates a local file in the SO
+
+
 Configuration file options
 --------------------------
 

--- a/pytest_testdox/constants.py
+++ b/pytest_testdox/constants.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
 TITLE_MARK = 'it'
+CLASS_NAME_MARK = 'describe'

--- a/pytest_testdox/constants.py
+++ b/pytest_testdox/constants.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+TITLE_MARK = 'it'

--- a/pytest_testdox/formatters.py
+++ b/pytest_testdox/formatters.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import re
 
+STRIP_WHITE_SPACES_REGEX = r'(^[\s]+|[\s]+$)'
 
 def format_title(title, patterns):
     return _remove_patterns(title, patterns).replace('_', ' ').strip()
@@ -24,6 +25,15 @@ def format_class_name(class_name, patterns):
 
 def format_module_name(module_name, patterns):
     return format_title(module_name.split('/')[-1], patterns)
+
+
+def format_multi_line_text(text):
+    return re.sub(
+        STRIP_WHITE_SPACES_REGEX,
+        '',
+        text,
+        flags=re.MULTILINE
+    )
 
 
 def _remove_patterns(statement, patterns):

--- a/pytest_testdox/formatters.py
+++ b/pytest_testdox/formatters.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import re
 import os
+import re
 
 STRIP_WHITE_SPACES_REGEX = r'(^[\s]+|[\s]+$)'
+
 
 def format_title(title, patterns):
     return _remove_patterns(title, patterns).replace('_', ' ').strip()
@@ -35,6 +36,7 @@ def format_multi_line_text(text):
         text,
         flags=re.MULTILINE
     )
+
 
 def pad_text_to_characters(characters, text):
     lines = text.split(os.linesep)

--- a/pytest_testdox/formatters.py
+++ b/pytest_testdox/formatters.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import re
+import os
 
 STRIP_WHITE_SPACES_REGEX = r'(^[\s]+|[\s]+$)'
 
@@ -34,6 +35,22 @@ def format_multi_line_text(text):
         text,
         flags=re.MULTILINE
     )
+
+def pad_text_to_characters(characters, text):
+    lines = text.split(os.linesep)
+    if len(lines) == 1:
+        return text
+
+    result = lines[0] + os.linesep
+
+    for line in lines[1:]:
+        if not line:
+            continue
+
+        pad = len(line) + len(characters)
+        result += line.rjust(pad) + os.linesep
+
+    return result
 
 
 def _remove_patterns(statement, patterns):

--- a/pytest_testdox/formatters.py
+++ b/pytest_testdox/formatters.py
@@ -43,16 +43,17 @@ def pad_text_to_characters(characters, text):
     if len(lines) == 1:
         return text
 
-    result = lines[0] + os.linesep
+    result = []
+    result.append(lines[0])
 
     for line in lines[1:]:
         if not line:
             continue
 
         pad = len(line) + len(characters)
-        result += line.rjust(pad) + os.linesep
+        result.append(line.rjust(pad))
 
-    return result
+    return os.linesep.join(result)
 
 
 def _remove_patterns(statement, patterns):

--- a/pytest_testdox/models.py
+++ b/pytest_testdox/models.py
@@ -76,9 +76,9 @@ class Node(object):
 class Result(object):
 
     _OUTCOME_REPRESENTATION = {
-        'passed': '[x]',
-        'failed': '[ ]',
-        'skipped': '>>>',
+        'passed': ' [x] ',
+        'failed': ' [ ] ',
+        'skipped': ' >>> ',
     }
     _default_outcome_representation = '>>>'
 
@@ -99,9 +99,12 @@ class Result(object):
             self._default_outcome_representation
         )
 
-        line = ' {outcome_representation} {node}'.format(
+        line = '{outcome_representation}{node}'.format(
             outcome_representation=representation,
-            node=self.node
+            node=formatters.pad_text_to_characters(
+                characters=representation,
+                text=six.text_type(self.node)
+            )
         )
 
         return line

--- a/pytest_testdox/models.py
+++ b/pytest_testdox/models.py
@@ -38,12 +38,10 @@ class Node(object):
         )
 
     @classmethod
-    def parse(cls, nodeid, pattern_config, overwrite_title=None):
+    def parse(cls, nodeid, pattern_config, title=None):
         node_parts = nodeid.split('::')
 
-        if overwrite_title:
-            title = overwrite_title
-        else:
+        if not title:
             title = formatters.format_title(
                 node_parts[-1],
                 pattern_config.functions
@@ -110,13 +108,13 @@ class Result(object):
     @classmethod
     def create(cls, report, pattern_config):
         try:
-            overwrite_title = report.testdox_title
+            title = report.testdox_title
         except AttributeError:
-            overwrite_title = None
+            title = None
 
         node = Node.parse(
             nodeid=report.nodeid,
             pattern_config=pattern_config,
-            overwrite_title=overwrite_title
+            title=title
         )
         return cls(report.outcome, node)

--- a/pytest_testdox/models.py
+++ b/pytest_testdox/models.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import re
 from collections import namedtuple
 
 import six
@@ -41,7 +42,9 @@ class Node(object):
     def parse(cls, nodeid, pattern_config, title=None, class_name=None):
         node_parts = nodeid.split('::')
 
-        if not title:
+        if title:
+            title = formatters.format_multi_line_text(title)
+        else:
             title = formatters.format_title(
                 node_parts[-1],
                 pattern_config.functions
@@ -52,7 +55,9 @@ class Node(object):
             pattern_config.files
         )
 
-        if not class_name:
+        if class_name:
+            class_name = formatters.format_multi_line_text(class_name)
+        else:
             if '()' in node_parts[-2]:
                 class_name = formatters.format_class_name(
                     node_parts[-3],

--- a/pytest_testdox/models.py
+++ b/pytest_testdox/models.py
@@ -109,5 +109,14 @@ class Result(object):
 
     @classmethod
     def create(cls, report, pattern_config):
-        node = Node.parse(report.nodeid, pattern_config)
+        try:
+            overwrite_title = report.testdox_title
+        except AttributeError:
+            overwrite_title = None
+
+        node = Node.parse(
+            nodeid=report.nodeid,
+            pattern_config=pattern_config,
+            overwrite_title=overwrite_title
+        )
         return cls(report.outcome, node)

--- a/pytest_testdox/models.py
+++ b/pytest_testdox/models.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import re
 from collections import namedtuple
 
 import six

--- a/pytest_testdox/models.py
+++ b/pytest_testdox/models.py
@@ -38,7 +38,7 @@ class Node(object):
         )
 
     @classmethod
-    def parse(cls, nodeid, pattern_config, title=None):
+    def parse(cls, nodeid, pattern_config, title=None, class_name=None):
         node_parts = nodeid.split('::')
 
         if not title:
@@ -52,17 +52,17 @@ class Node(object):
             pattern_config.files
         )
 
-        class_name = None
-        if '()' in node_parts[-2]:
-            class_name = formatters.format_class_name(
-                node_parts[-3],
-                pattern_config.classes
-            )
-        elif len(node_parts) > 2:
-            class_name = formatters.format_class_name(
-                node_parts[-2],
-                pattern_config.classes
-            )
+        if not class_name:
+            if '()' in node_parts[-2]:
+                class_name = formatters.format_class_name(
+                    node_parts[-3],
+                    pattern_config.classes
+                )
+            elif len(node_parts) > 2:
+                class_name = formatters.format_class_name(
+                    node_parts[-2],
+                    pattern_config.classes
+                )
 
         return cls(title=title, class_name=class_name, module_name=module_name)
 
@@ -107,14 +107,13 @@ class Result(object):
 
     @classmethod
     def create(cls, report, pattern_config):
-        try:
-            title = report.testdox_title
-        except AttributeError:
-            title = None
+        title = getattr(report, 'testdox_title', None)
+        class_name = getattr(report, 'testdox_class_name', None)
 
         node = Node.parse(
             nodeid=report.nodeid,
             pattern_config=pattern_config,
-            title=title
+            title=title,
+            class_name=class_name
         )
         return cls(report.outcome, node)

--- a/pytest_testdox/models.py
+++ b/pytest_testdox/models.py
@@ -38,12 +38,17 @@ class Node(object):
         )
 
     @classmethod
-    def parse(cls, nodeid, pattern_config):
+    def parse(cls, nodeid, pattern_config, overwrite_title=None):
         node_parts = nodeid.split('::')
-        title = formatters.format_title(
-            node_parts[-1],
-            pattern_config.functions
-        )
+
+        if overwrite_title:
+            title = overwrite_title
+        else:
+            title = formatters.format_title(
+                node_parts[-1],
+                pattern_config.functions
+            )
+
         module_name = formatters.format_module_name(
             node_parts[0],
             pattern_config.files

--- a/pytest_testdox/models.py
+++ b/pytest_testdox/models.py
@@ -29,6 +29,14 @@ class Node(object):
             self.module_name
         )
 
+    def __eq__(self, other):
+        return (
+            type(self) == type(other) and
+            self.title == other.title and
+            self.class_name == other.class_name and
+            self.module_name == other.module_name
+        )
+
     @classmethod
     def parse(cls, nodeid, pattern_config):
         node_parts = nodeid.split('::')

--- a/pytest_testdox/plugin.py
+++ b/pytest_testdox/plugin.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 import pytest
 from _pytest.terminal import TerminalReporter
 
-from . import models, wrappers
+from . import models, wrappers, constants
 
 
 def pytest_addoption(parser):
@@ -30,7 +30,9 @@ def pytest_configure(config):
         config.pluginmanager.register(testdox_reporter, 'terminalreporter')
         config.addinivalue_line(
             "markers",
-            "testdox_title(title): Override testdox report title"
+            "{}(title): Override testdox report test title".format(
+                constants.TITLE_MARK
+            )
         )
 
 
@@ -42,7 +44,7 @@ def pytest_runtest_makereport(item, call):
 
     testdox_title = _first(
         mark.args[0]
-        for mark in item.iter_markers(name='testdox_title')
+        for mark in item.iter_markers(name=constants.TITLE_MARK)
     )
     if testdox_title:
         report.testdox_title = testdox_title

--- a/pytest_testdox/plugin.py
+++ b/pytest_testdox/plugin.py
@@ -2,9 +2,10 @@
 from __future__ import unicode_literals
 
 import pytest
+
 from _pytest.terminal import TerminalReporter
 
-from . import models, wrappers, constants
+from . import constants, models, wrappers
 
 
 def pytest_addoption(parser):
@@ -61,6 +62,7 @@ def pytest_runtest_makereport(item, call):
 
     if testdox_class_name:
         report.testdox_class_name = testdox_class_name
+
 
 class TestdoxTerminalReporter(TerminalReporter):
 

--- a/pytest_testdox/plugin.py
+++ b/pytest_testdox/plugin.py
@@ -34,6 +34,12 @@ def pytest_configure(config):
                 constants.TITLE_MARK
             )
         )
+        config.addinivalue_line(
+            "markers",
+            "{}(title): Override testdox report class title".format(
+                constants.CLASS_NAME_MARK
+            )
+        )
 
 
 @pytest.hookimpl(hookwrapper=True)
@@ -46,9 +52,15 @@ def pytest_runtest_makereport(item, call):
         mark.args[0]
         for mark in item.iter_markers(name=constants.TITLE_MARK)
     )
+    testdox_class_name = _first(
+        mark.args[0]
+        for mark in item.iter_markers(name=constants.CLASS_NAME_MARK)
+    )
     if testdox_title:
         report.testdox_title = testdox_title
 
+    if testdox_class_name:
+        report.testdox_class_name = testdox_class_name
 
 class TestdoxTerminalReporter(TerminalReporter):
 

--- a/pytest_testdox/wrappers.py
+++ b/pytest_testdox/wrappers.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import six
+
+from . import formatters
+
 
 class Wrapper(object):
 
@@ -34,19 +38,22 @@ class ColorWrapper(Wrapper):
 class UTF8Wrapper(Wrapper):
 
     _CHARACTER_BY_OUTCOME = {
-        'passed': '✓',
-        'failed': '✗',
-        'skipped': '»',
+        'passed': ' ✓ ',
+        'failed': ' ✗ ',
+        'skipped': ' » ',
     }
 
-    _default_character = '»'
+    _default_character = ' » '
 
     def __str__(self):
         outcome = self._CHARACTER_BY_OUTCOME.get(
             self.wrapped.outcome,
             self._default_character
         )
-        return ' {outcome} {node}'.format(
+        return '{outcome}{node}'.format(
             outcome=outcome,
-            node=self.wrapped.node
+            node=formatters.pad_text_to_characters(
+                characters=outcome,
+                text=six.text_type(self.wrapped.node)
+            )
         )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,4 @@ flake8==3.3.0
 isort==4.2.5
 mock==2.0.0
 pytest-cov==2.4.0
-pytest>=3.0.0
+pytest>=3.6.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     url='https://github.com/renanivo/pytest-testdox',
     keywords='pytest testdox test report bdd',
     install_requires=[
-        'pytest>=3.0.0',
+        'pytest>=3.6.0',
         'six>=1.11.0',
     ],
     packages=['pytest_testdox'],

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+import os
 
 import pytest
 from pytest_testdox import formatters
@@ -106,4 +107,33 @@ class TestFormatMultiLineText(object):
         ''') == (
             'works when used in very specific\n'
             'conditions of temperature and pressure'
+        )
+
+
+class TestJustifyTextToCharacter(object):
+
+    def test_should_not_pad_single_line_text(self):
+        assert formatters.pad_text_to_characters('>>>', 'some text') == (
+            'some text'
+        )
+
+    def test_should_pad_the_following_lines_to_the_width_of_given_characters(
+        self
+    ):
+        text = (
+            'first line{0}'
+            'second line{0}'
+            '{0}'
+            'third line{0}'
+            'fourth line{0}'
+        ).format(
+            os.linesep
+        )
+        assert formatters.pad_text_to_characters('>>>', text) == (
+            'first line{0}'
+            '   second line{0}'
+            '   third line{0}'
+            '   fourth line{0}'.format(
+                os.linesep
+            )
         )

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -127,7 +127,7 @@ class TestJustifyTextToCharacter(object):
             'second line{0}'
             '{0}'
             'third line{0}'
-            'fourth line{0}'
+            'fourth line'
         ).format(
             os.linesep
         )
@@ -135,7 +135,7 @@ class TestJustifyTextToCharacter(object):
             'first line{0}'
             '   second line{0}'
             '   third line{0}'
-            '   fourth line{0}'.format(
+            '   fourth line'.format(
                 os.linesep
             )
         )

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+
 import os
 
 import pytest
+
 from pytest_testdox import formatters
 
 

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -92,3 +92,18 @@ class TestFormatModuleName(object):
         )
 
         assert formatted == 'module'
+
+
+class TestFormatMultiLineText(object):
+
+    def test_should_strip_spaces_from_begin_and_end(self):
+        assert formatters.format_multi_line_text('  works   ') == 'works'
+
+    def test_should_srip_spaces_from_multiple_lines(self):
+        assert formatters.format_multi_line_text('''
+            works when used in very specific
+            conditions of temperature and pressure
+        ''') == (
+            'works when used in very specific\n'
+            'conditions of temperature and pressure'
+        )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -16,6 +16,7 @@ def node():
 @pytest.fixture
 def report():
     return mock.Mock(
+        spec=('nodeid', 'outcome'),
         nodeid='folder/test_file.py::test_title',
         outcome='passed'
     )
@@ -127,3 +128,15 @@ class TestResult(object):
         assert isinstance(result, Result)
         assert result.outcome == report.outcome
         assert result.node == Node.parse(report.nodeid, pattern_config)
+
+    def test_create_should_call_parse_with_overwritten_title(
+        self,
+        report,
+        pattern_config
+    ):
+        report.testdox_title = 'some title'
+        result = Result.create(report, pattern_config)
+
+        assert result.node == Node.parse(nodeid=report.nodeid,
+                                         pattern_config=pattern_config,
+                                         overwrite_title=report.testdox_title)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -50,15 +50,21 @@ class TestNode(object):
                                           pattern_config.files)
         )
 
-    def test_parse_should_use_overridden_title_instead_of_parse_node_id(
+    @pytest.mark.parametrize(('attribute,value'), (
+        ('title', 'new title'),
+        ('class_name', 'new class name'),
+    ))
+    def test_parse_should_use_overridden_attribute_instead_of_parse_node_id(
         self,
+        attribute,
+        value,
         pattern_config
     ):
         nodeid = 'tests/test_module.py::test_title'
 
-        node = Node.parse(nodeid, pattern_config, title='new title')
+        node = Node.parse(nodeid, pattern_config, **{attribute: value})
 
-        assert node.title == 'new title'
+        assert getattr(node, attribute) == value
 
     @pytest.mark.parametrize('nodeid,class_name', (
         ('tests/test_module.py::test_title', None),
@@ -129,14 +135,24 @@ class TestResult(object):
         assert result.outcome == report.outcome
         assert result.node == Node.parse(report.nodeid, pattern_config)
 
-    def test_create_should_call_parse_with_overridden_title(
+    @pytest.mark.parametrize('report_attribute,parameter,value', (
+        ('testdox_title', 'title', 'some title'),
+        ('testdox_class_name', 'class_name', 'some class name'),
+    ))
+    def test_create_should_call_parse_with_overridden_attributes(
         self,
+        report_attribute,
+        parameter,
+        value,
         report,
         pattern_config
     ):
-        report.testdox_title = 'some title'
+        setattr(report, report_attribute, value)
+
         result = Result.create(report, pattern_config)
+
+        kwargs = {parameter: value}
 
         assert result.node == Node.parse(nodeid=report.nodeid,
                                          pattern_config=pattern_config,
-                                         title=report.testdox_title)
+                                         **kwargs)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+
 import os
 
 import mock

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -51,8 +51,8 @@ class TestNode(object):
         )
 
     @pytest.mark.parametrize(('attribute,value'), (
-        ('title', 'new title'),
-        ('class_name', 'new class name'),
+        ('title', ' new title '),
+        ('class_name', ' new class name '),
     ))
     def test_parse_should_use_overridden_attribute_instead_of_parse_node_id(
         self,
@@ -64,7 +64,9 @@ class TestNode(object):
 
         node = Node.parse(nodeid, pattern_config, **{attribute: value})
 
-        assert getattr(node, attribute) == value
+        result = getattr(node, attribute)
+
+        assert result == formatters.format_multi_line_text(value)
 
     @pytest.mark.parametrize('nodeid,class_name', (
         ('tests/test_module.py::test_title', None),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+import os
 
 import mock
 import pytest
@@ -91,7 +92,7 @@ class TestNode(object):
         assert from_repr.class_name == node.class_name
         assert from_repr.module_name == node.module_name
 
-    def test_shoud_be_equal_when_objects_have_the_same_attributes(self, node):
+    def test_should_be_equal_when_objects_have_the_same_attributes(self, node):
         other = Node(
             title=node.title,
             class_name=node.class_name,
@@ -158,3 +159,15 @@ class TestResult(object):
         assert result.node == Node.parse(nodeid=report.nodeid,
                                          pattern_config=pattern_config,
                                          **kwargs)
+
+    def test_str_should_pad_text_to_outcome_characters(
+        self,
+        node
+    ):
+        node.title = 'some{}text'.format(os.linesep)
+        result = Result('passed', node)
+
+        assert formatters.pad_text_to_characters(
+            ' [x] ',
+            node.title
+        ) in str(result)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -62,6 +62,24 @@ class TestNode(object):
         assert from_repr.class_name == node.class_name
         assert from_repr.module_name == node.module_name
 
+    def test_shoud_be_equal_when_objects_have_the_same_attributes(self, node):
+        other = Node(
+            title=node.title,
+            class_name=node.class_name,
+            module_name=node.module_name
+        )
+
+        assert node == other
+
+    def test_should_not_be_equal_when_it_is_not_the_same_class(self, node):
+        other = mock.Mock(
+            title=node.title,
+            class_name=node.class_name,
+            module_name=node.module_name
+        )
+
+        assert node != other
+
 
 class TestResult(object):
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -50,13 +50,13 @@ class TestNode(object):
                                           pattern_config.files)
         )
 
-    def test_parse_should_use_overwritten_title_instead_of_parse_node_id(
+    def test_parse_should_use_overridden_title_instead_of_parse_node_id(
         self,
         pattern_config
     ):
         nodeid = 'tests/test_module.py::test_title'
 
-        node = Node.parse(nodeid, pattern_config, overwrite_title='new title')
+        node = Node.parse(nodeid, pattern_config, title='new title')
 
         assert node.title == 'new title'
 
@@ -129,7 +129,7 @@ class TestResult(object):
         assert result.outcome == report.outcome
         assert result.node == Node.parse(report.nodeid, pattern_config)
 
-    def test_create_should_call_parse_with_overwritten_title(
+    def test_create_should_call_parse_with_overridden_title(
         self,
         report,
         pattern_config
@@ -139,4 +139,4 @@ class TestResult(object):
 
         assert result.node == Node.parse(nodeid=report.nodeid,
                                          pattern_config=pattern_config,
-                                         overwrite_title=report.testdox_title)
+                                         title=report.testdox_title)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -131,11 +131,11 @@ class TestReport(object):
         lines = result.stdout.get_lines_after('Test')
         assert '✓ runs' in lines[0]
 
-    def test_should_overwrite_titles_with_testdox_title_mark(self, testdir):
+    def test_should_override_titles_with_testdox_title_mark(self, testdir):
         testdir.makefile('.py', test_module_name="""
             import pytest
 
-            @pytest.mark.{}('overwritten title')
+            @pytest.mark.{}('overridden title')
             def test_a_passing_test():
                 assert True
         """.format(
@@ -144,4 +144,4 @@ class TestReport(object):
 
         result = testdir.runpytest('--testdox')
 
-        assert 'overwritten title' in result.stdout.str()
+        assert 'overridden title' in result.stdout.str()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals
 
 import pytest
 
+from pytest_testdox import constants
+
 
 class TestReport(object):
 
@@ -133,10 +135,12 @@ class TestReport(object):
         testdir.makefile('.py', test_module_name="""
             import pytest
 
-            @pytest.mark.testdox_title('overwritten title')
+            @pytest.mark.{}('overwritten title')
             def test_a_passing_test():
                 assert True
-        """)
+        """.format(
+            constants.TITLE_MARK
+        ))
 
         result = testdir.runpytest('--testdox')
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -128,3 +128,16 @@ class TestReport(object):
 
         lines = result.stdout.get_lines_after('Test')
         assert '✓ runs' in lines[0]
+
+    def test_should_overwrite_titles_with_testdox_title_mark(self, testdir):
+        testdir.makefile('.py', test_module_name="""
+            import pytest
+
+            @pytest.mark.testdox_title('overwritten title')
+            def test_a_passing_test():
+                assert True
+        """)
+
+        result = testdir.runpytest('--testdox')
+
+        assert 'overwritten title' in result.stdout.str()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -131,11 +131,17 @@ class TestReport(object):
         lines = result.stdout.get_lines_after('Test')
         assert '✓ runs' in lines[0]
 
-    def test_should_override_titles_with_testdox_title_mark(self, testdir):
+    def test_should_override_test_titles_with_title_mark(
+        self,
+        testdir
+    ):
         testdir.makefile('.py', test_module_name="""
             import pytest
 
-            @pytest.mark.{}('overridden title')
+            @pytest.mark.{}('''
+                My Title
+                My precious title
+            ''')
             def test_a_passing_test():
                 assert True
         """.format(
@@ -144,4 +150,27 @@ class TestReport(object):
 
         result = testdir.runpytest('--testdox')
 
-        assert 'overridden title' in result.stdout.str()
+        assert 'My Title\n   My precious title' in result.stdout.str()
+
+    def test_should_override_class_names_with_class_name_mark(
+        self,
+        testdir
+    ):
+        testdir.makefile('.py', test_module_name="""
+            import pytest
+
+            @pytest.mark.{}('''
+                My Class
+                My precious class
+            ''')
+            class TestClass(object):
+
+                def test_foo(self):
+                    pass
+        """.format(
+            constants.CLASS_NAME_MARK
+        ))
+
+        result = testdir.runpytest('--testdox')
+
+        assert 'My Class\nMy precious class' in result.stdout.str()


### PR DESCRIPTION
closes #19 

This Pull Request recognizes the content of the marker `@pytest.mark.describe` to override class names and `@pytest.mark.it` to override test titles in the test report.