### PR TITLE
Fix mark.it titles when used with mark.parametrize

### DIFF
--- a/pytest_testdox/formatters.py
+++ b/pytest_testdox/formatters.py
@@ -56,6 +56,23 @@ def pad_text_to_characters(characters, text):
     return os.linesep.join(result)
 
 
+def include_parametrized(title, original_title):
+    first_bracket = original_title.find('[')
+    last_bracket = original_title.rfind(']')
+
+    has_parameters = last_bracket > first_bracket
+
+    if not has_parameters:
+        return title
+
+    parameters = original_title[first_bracket + 1:last_bracket]
+
+    return '{title}[{parameters}]'.format(
+        title=title,
+        parameters=parameters
+    )
+
+
 def _remove_patterns(statement, patterns):
     for glob_pattern in patterns:
         pattern = glob_pattern.replace('*', '')

--- a/pytest_testdox/models.py
+++ b/pytest_testdox/models.py
@@ -42,7 +42,10 @@ class Node(object):
         node_parts = nodeid.split('::')
 
         if title:
-            title = formatters.format_multi_line_text(title)
+            title = formatters.include_parametrized(
+                formatters.format_multi_line_text(title),
+                node_parts[-1]
+            )
         else:
             title = formatters.format_title(
                 node_parts[-1],

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -139,3 +139,24 @@ class TestJustifyTextToCharacter(object):
                 os.linesep
             )
         )
+
+
+class TestIncludeParametrized(object):
+
+    def test_should_return_title_when_no_parameters_are_found(self):
+        assert formatters.include_parametrized(
+            title='Should return value',
+            original_title='test_should_return_value'
+        ) == 'Should return value'
+
+    def test_should_return_parameters_in_title(self):
+        assert formatters.include_parametrized(
+            title='A title',
+            original_title='test_should_return_value[params]'
+        ) == 'A title[params]'
+
+    def test_should_return_parameters_containing_brackets(self):
+        assert formatters.include_parametrized(
+            title='A title',
+            original_title='test_should_return_value[[[[params]]]]'
+        ) == 'A title[[[[params]]]]'

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -192,7 +192,8 @@ class TestReport(object):
 
         result = testdir.runpytest('--testdox')
 
-        assert 'should pass with parameters[param' in result.stdout.str()
+        assert 'should pass with parameters[param1]' in result.stdout.str()
+        assert 'should pass with parameters[param2]' in result.stdout.str()
 
     def test_decorator_order_should_not_affect_parametrize(
         self,
@@ -211,4 +212,5 @@ class TestReport(object):
 
         result = testdir.runpytest('--testdox')
 
-        assert 'should pass with parameters[param' in result.stdout.str()
+        assert 'should pass with parameters[param1]' in result.stdout.str()
+        assert 'should pass with parameters[param2]' in result.stdout.str()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -174,3 +174,25 @@ class TestReport(object):
         result = testdir.runpytest('--testdox')
 
         assert 'My Class\nMy precious class' in result.stdout.str()
+
+    def test_should_override_test_titles_with_title_mark_parametrize(
+        self,
+        testdir
+    ):
+        testdir.makefile('.py', test_module_name="""
+            import pytest
+
+            @pytest.mark.parametrize('par', ['param1', 'param2'])
+            @pytest.mark.{}('''
+                My Title
+                My precious title
+            ''')
+            def test_a_passing_test(par):
+                assert True
+        """.format(
+            constants.TITLE_MARK
+        ))
+
+        result = testdir.runpytest('--testdox')
+
+        assert 'My Title\n   My precious title[param' in result.stdout.str()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -193,3 +193,22 @@ class TestReport(object):
         result = testdir.runpytest('--testdox')
 
         assert 'should pass with parameters[param' in result.stdout.str()
+
+    def test_decorator_order_should_not_affect_parametrize(
+        self,
+        testdir
+    ):
+        testdir.makefile('.py', test_module_name="""
+            import pytest
+
+            @pytest.mark.{}('should pass with parameters')
+            @pytest.mark.parametrize('par', ['param1', 'param2'])
+            def test_a_passing_test(par):
+                assert True
+        """.format(
+            constants.TITLE_MARK
+        ))
+
+        result = testdir.runpytest('--testdox')
+
+        assert 'should pass with parameters[param' in result.stdout.str()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -183,10 +183,7 @@ class TestReport(object):
             import pytest
 
             @pytest.mark.parametrize('par', ['param1', 'param2'])
-            @pytest.mark.{}('''
-                My Title
-                My precious title
-            ''')
+            @pytest.mark.{}('should pass with parameters')
             def test_a_passing_test(par):
                 assert True
         """.format(
@@ -195,4 +192,4 @@ class TestReport(object):
 
         result = testdir.runpytest('--testdox')
 
-        assert 'My Title\n   My precious title[param' in result.stdout.str()
+        assert 'should pass with parameters[param' in result.stdout.str()


### PR DESCRIPTION
Allow use of custom titles using `pytest.mark.it` along with parametrized tests. Fixes #22.

When `mark.parametrize` is used, pytest includes the parameters in the last part of `nodeid` (e.g. `test_module_name.py::test_a_passing_test[this is a param]`).
I used the fact that function names cannot contain brackets to safely extract parameters. Parameters may include brackets, though.

I think function names and arguments I wrote may need a more thorough review.