### PR TITLE
Update README.rst with correct section usage for setup.cfg

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,9 +40,12 @@ in your `ini file <https://docs.pytest.org/en/latest/customize.html#initializati
 
 .. code-block:: ini
 
-    # content of pytest.ini
-    # (or tox.ini or setup.cfg)
+    # content of pytest.ini or tox.ini
     [pytest]
+    addopts = --testdox
+
+    # or if you use setup.cfg
+    [tool:pytest]
     addopts = --testdox
 
 When using ``--testdox``, the plugin will disable itself when not running on a


### PR DESCRIPTION
Hi @renanivo 👋 

Really appreciate your work with this package and I'm surprised that it's actually not a standard feature of pytest itself?

Anyway, this PR fixes a small deprecation warning with setup.cfg that I ran into when following the instructions in the readme.

![image](https://user-images.githubusercontent.com/13087421/82403914-91308400-9a92-11ea-864c-ebd7e5b455be.png)

Cheers :)