### PR TITLE
Run tests on GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,57 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9-dev, pypy3]
+        os: [ubuntu-latest, macos-latest]
+        pytest: [
+          "pytest==3.7.0",
+          "pytest>3.7.0,<4.0.0",
+          "pytest>=4.0.0,<5.0.0",
+          "pytest>=5.0.0,<6.0.0",
+          "pytest>=6.0.0,<7.0.0",
+        ]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+
+      - name: pip cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key:
+            ${{ matrix.os }}-${{ matrix.python-version }}-v2-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ matrix.os }}-${{ matrix.python-version }}-v2-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install "${{ matrix.pytest }}"
+          make install
+
+      - name: Test
+        shell: bash
+        run: |
+          make check test
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v1
+        with:
+          name: ${{ matrix.os }} Python ${{ matrix.python-version }} ${{ matrix.pytest }}


### PR DESCRIPTION
For #37.

* Test Python 3.5-3.8 and PyPy3.

* Also test 3.9-dev, currently pointing to the last beta, as it's strongly recommended to test third-party libraries before the final 3.9.0 release in October.

* Test on Ubuntu and macOS.

* Also test the latest pytest 6 (for #36).

* Not done the deploy part from `.travis.yml`, that can be done in a separate `deploy.yml`.

Example run:

* https://github.com/hugovk/pytest-testdox/runs/922569671?check_suite_focus=true