### PR TITLE
Fix Continuous Integration badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pytest-testdox
 
 [![PyPI](https://img.shields.io/pypi/v/pytest-testdox.svg?color=brightgreen)](https://pypi.org/project/pytest-testdox/)
-[![Build Status](https://github.com/renanivo/pytest-testdox/workflows/ci/badge.svg)](https://github.com/renanivo/pytest-testdox/actions)
+[![Continuous Integration Status](https://github.com/renanivo/pytest-testdox/workflows/Continuous%20Integration/badge.svg)](https://github.com/renanivo/pytest-testdox/actions?query=workflow%3A%22Continuous+Integration%22)
 [![codecov](https://codecov.io/gh/renanivo/pytest-testdox/branch/master/graph/badge.svg)](https://codecov.io/gh/renanivo/pytest-testdox)
 
 A [TestDox format](https://en.wikipedia.org/wiki/TestDox) reporter for pytest.


### PR DESCRIPTION
A very little detail was preventing the badge to render properly. Turns out you should use the title of the workflow instead of the file name at the badge URL.