### PR TITLE
Support [skip ci] and [ci skip]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ name: Continuous Integration
 on: [push, pull_request]
 
 jobs:
-  build:
+  ci:
     runs-on: ${{ matrix.os }}
+    if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Modern CI software have a way to use commit messages to skip the build.
This is handy when updating docs, comments and files not affected by
tests.