### PR TITLE
Fix missing header when same class name is used in two modules

### DIFF
--- a/pytest_testdox/models.py
+++ b/pytest_testdox/models.py
@@ -108,6 +108,15 @@ class Result:
     def header(self):
         return self.node.class_name or self.node.module_name
 
+    @property
+    def header_id(self):
+        """
+        Return the same value when the result should be aggregated under the
+        same class or module (this is not guaranteed in "header" property,
+        which should be used when displaying to the user)
+        """
+        return self.node.module_name + (self.node.class_name or '')
+
     @classmethod
     def create(cls, report, pattern_config):
         title = getattr(report, 'testdox_title', None)

--- a/pytest_testdox/plugin.py
+++ b/pytest_testdox/plugin.py
@@ -125,10 +125,7 @@ class TestdoxTerminalReporter(TerminalReporter):
             self._tw.sep(' ')
             self._tw.line(result.header)
 
-        try:
-            self._tw.line(unicode(result))
-        except NameError:
-            self._tw.line(str(result))
+        self._tw.line(str(result))
 
 
 def _first(iterator):

--- a/pytest_testdox/plugin.py
+++ b/pytest_testdox/plugin.py
@@ -79,7 +79,7 @@ class TestdoxTerminalReporter(TerminalReporter):
 
     def __init__(self, config, file=None):
         super().__init__(config, file)
-        self._last_header = None
+        self._last_header_id = None
         self.pattern_config = models.PatternConfig(
             files=self.config.getini('python_files'),
             functions=self.config.getini('python_functions'),
@@ -120,8 +120,8 @@ class TestdoxTerminalReporter(TerminalReporter):
         for wrapper in self.result_wrappers:
             result = wrapper(result)
 
-        if result.header != self._last_header:
-            self._last_header = result.header
+        if result.header_id != self._last_header_id:
+            self._last_header_id = result.header_id
             self._tw.sep(' ')
             self._tw.line(result.header)
 


### PR DESCRIPTION
When the same class name was used in two or more modules which were added to the report in sequence, only the first class name was displayed. It happened because the plugin tracked differences in Result.header in each test result and only the class name (without its module) was set in it.

Output before:
```
test_first.py
Foo
 ✓ a feature is working
                                                                         [ 50%]
test_second.py  ✓ a feature is working in another module
                                                                         [100%]
```

Output after:
```
test_first.py
Foo
 ✓ a feature is working
                                                                         [ 50%]
test_second.py
Foo
 ✓ a feature is working in another module
                                                                         [100%]
```