### PR TITLE
Update the minimum pytest requirement in setup.py to 4.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     url='https://github.com/renanivo/pytest-testdox',
     keywords='pytest testdox test report bdd',
     install_requires=[
-        'pytest>=3.7.0',
+        'pytest>=4.6.0',
     ],
     packages=['pytest_testdox'],
     python_requires=">=3.6",


### PR DESCRIPTION
After #54, some Pytest versions are not supported anymore, so the
`install_requires` in `setup.py` should reflect that, so that the
package can't be installed with unsupported dependencies.