### PR TITLE
Run tests with PyPy 3.8 instead of 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy3"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy-3.8"]
         os: [ubuntu-latest, macos-latest]
         pytest:
           [


### PR DESCRIPTION
`pypy3` stands for PyPy 3.5 in github actions. To make my life easier, from now on, this project will run tests only in the latest version of PyPy.