### PR TITLE
Make dependabot ignore patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
   directory: "/"
   schedule:
     interval: monthly
+  ignore:
+    - dependency-name: "*"
+      update-types: ["version-update:semver-patch"]
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
Most dependencies in requirements-dev.txt will install the latest patch
anyway.