### PR TITLE
Fix DeprecationWarning with hookimpl decorator

### DIFF
--- a/pytest_testdox/plugin.py
+++ b/pytest_testdox/plugin.py
@@ -45,7 +45,7 @@ def should_enable_plugin(config: Config):
     ) or config.option.force_testdox
 
 
-@pytest.mark.trylast
+@pytest.hookimpl(trylast=True)
 def pytest_configure(config: Config):
     config.addinivalue_line(
         "markers",


### PR DESCRIPTION
See https://docs.pytest.org/en/latest/deprecations.html#configuring-hook-specs-impls-using-markers.

```
  /home/test/.cache/pypoetry/virtualenvs/test-py3.11/lib/python3.11/site-packages/pytest_testdox/plugin.py:38: PytestDeprecationWarning: The hookimpl pytest_configure uses old-style configuration options (marks or attributes).
  Please use the pytest.hookimpl(trylast=True) decorator instead
   to configure the hooks.
   See https://docs.pytest.org/en/latest/deprecations.html#configuring-hook-specs-impls-using-markers
    @pytest.mark.trylast
```

@renanivo would you be able to publish a release after this is merged to get it out to users? :) I use your plugin in a library that is distributed to others (not just my own tests) so would be great to see it released :bow: 