### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.9"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "pypy-3.9"]
         os: [ubuntu-latest, macos-latest]
         pytest:
           [


### PR DESCRIPTION
So that we can use the latest versions of isort and flake8